### PR TITLE
Add Ansible playbook to automate Debian AD join

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Here are my networking labs, such as network-related programs.
 ## Documentation
 
 - [Joining Debian to Active Directory](docs/debian-ad-setup.md)
+
+## Automation
+
+- [Ansible playbook for Debian AD join](ansible/debian-ad-join.yml)

--- a/ansible/debian-ad-join.yml
+++ b/ansible/debian-ad-join.yml
@@ -1,0 +1,57 @@
+---
+- name: Join Debian to Active Directory
+  hosts: all
+  become: yes
+  vars:
+    domain: example.com
+    domain_base_dn: dc=example,dc=com
+    ad_user: Administrator
+    packages:
+      - realmd
+      - sssd
+      - sssd-tools
+      - libnss-sss
+      - libpam-sss
+      - adcli
+      - samba-common-bin
+      - oddjob
+      - oddjob-mkhomedir
+      - packagekit
+
+  tasks:
+    - name: Install required packages
+      apt:
+        name: "{{ packages }}"
+        state: present
+        update_cache: yes
+
+    - name: Join domain
+      command: realm join -U {{ ad_user }} {{ domain }}
+      register: realm_join
+      changed_when: "'already joined' not in realm_join.stdout"
+
+    - name: Configure SSSD
+      copy:
+        dest: /etc/sssd/sssd.conf
+        content: |
+          [sssd]
+          services = nss, pam
+          config_file_version = 2
+          domains = {{ domain }}
+
+          [domain/{{ domain }}]
+          id_provider = ad
+          ad_domain = {{ domain }}
+          auth_provider = ad
+          access_provider = ad
+          ldap_sudo_search_base = ou=Sudoers,{{ domain_base_dn }}
+        owner: root
+        group: root
+        mode: '0600'
+      notify: restart sssd
+
+  handlers:
+    - name: restart sssd
+      service:
+        name: sssd
+        state: restarted

--- a/docs/debian-ad-setup.md
+++ b/docs/debian-ad-setup.md
@@ -73,6 +73,8 @@ Verify `/etc/nsswitch.conf` contains `sss` entries for `passwd`, `group` and `sh
 
 ## Automation Hints
 
-* Wrap the above steps into an Ansible playbook using the `realm` and `sssd_conf` modules.
+* The repository includes an example playbook at
+  [`ansible/debian-ad-join.yml`](../ansible/debian-ad-join.yml) that installs the
+  required packages, joins the host to the domain and configures SSSD.
 * Use cloud-init or shell scripts to automate package installation and domain join during provisioning.
 


### PR DESCRIPTION
## Summary
- add `ansible/debian-ad-join.yml` with tasks for package install, realm join, and SSSD config
- document the new playbook in `docs/debian-ad-setup.md`
- link playbook from README under a new Automation section

## Testing
- `ansible-playbook --syntax-check ansible/debian-ad-join.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684058c8ae5083228877e6b8d69927fa